### PR TITLE
Implement url state format for color scales

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,10 +21,14 @@ const tools = [
 export default function HomePage() {
   const router = useRouter();
 
-  // Redirect to color-scales if there's URL hash data (for backward compatibility)
+  // Redirect to color-scales if there's URL state (query or hash)
   useEffect(() => {
-    if (typeof window !== 'undefined' && window.location.hash) {
-      router.replace('/color-scales' + window.location.hash);
+    if (typeof window !== 'undefined') {
+      const hasQuery = window.location.search && window.location.search.length > 1;
+      const hasHash = window.location.hash && window.location.hash.length > 1;
+      if (hasQuery || hasHash) {
+        router.replace('/color-scales' + (hasQuery ? window.location.search : '') + (hasHash ? window.location.hash : ''));
+      }
     }
   }, [router]);
 

--- a/components/ColorScaleGenerator.tsx
+++ b/components/ColorScaleGenerator.tsx
@@ -45,7 +45,9 @@ export default function ColorScaleGenerator() {
       setIsAppReady(true);
     } else {
       // No existing scales, check if we should add a starter
-      const hasUrlState = window.location.hash && window.location.hash.length > 1;
+      const hasQuery = typeof window !== 'undefined' && (window.location.search.length > 1);
+      const hasHash = typeof window !== 'undefined' && (window.location.hash && window.location.hash.length > 1);
+      const hasUrlState = hasQuery || hasHash;
       if (!hasUrlState) {
         // Add a starter color scale
         addColorScale();

--- a/lib/colorScaleStore.ts
+++ b/lib/colorScaleStore.ts
@@ -85,6 +85,140 @@ class HashStorage implements StateStorage {
   }
 }
 
+// New: Query string storage adapter for Zustand
+class QueryStringStorage implements StateStorage {
+  private parseScaleParam(param: string, index: number): ColorScaleData | null {
+    try {
+      const firstColon = param.indexOf(':');
+      if (firstColon === -1) return null;
+
+      const rawName = param.slice(0, firstColon);
+      const name = decodeURIComponent(rawName);
+
+      const rest = param.slice(firstColon + 1);
+      const [colorPart, ...restParts] = rest.split(',');
+      const keyColor = decodeURIComponent(colorPart || '').trim();
+
+      if (!keyColor) return null;
+
+      let hueShift = 0;
+      let chromaShift = 0;
+
+      for (const part of restParts) {
+        const sep = part.indexOf(':');
+        if (sep === -1) continue;
+        const k = part.slice(0, sep).trim();
+        const v = part.slice(sep + 1).trim();
+        if (k === 'h') {
+          const n = Number(v);
+          if (!Number.isNaN(n)) hueShift = n;
+        } else if (k === 'c') {
+          const n = Number(v);
+          if (!Number.isNaN(n)) chromaShift = n;
+        }
+      }
+
+      // Use existing helper to ensure consistent data shape (generates id)
+      return generateColorScaleData(keyColor, name, hueShift, chromaShift);
+    } catch {
+      return null;
+    }
+  }
+
+  private serializeScaleParam(scale: ColorScaleData): string {
+    const name = encodeURIComponent(scale.name);
+    const color = encodeURIComponent(scale.keyColor);
+    const parts: string[] = [`${name}:${color}`];
+    if (scale.hueShift && scale.hueShift !== 0) parts.push(`h:${scale.hueShift}`);
+    if (scale.chromaShift && scale.chromaShift !== 0) parts.push(`c:${scale.chromaShift}`);
+    return parts.join(',');
+  }
+
+  async getItem(name: string): Promise<string | null> {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    const search = window.location.search;
+    const params = new URLSearchParams(search);
+    const sParams = params.getAll('s');
+
+    if (sParams.length > 0 || params.has('prefix') || params.has('useThemeBlock') || params.has('output')) {
+      const scales: ColorScaleData[] = [];
+      sParams.forEach((p, i) => {
+        const parsed = this.parseScaleParam(p, i);
+        if (parsed) scales.push(parsed);
+      });
+
+      const prefix = params.get('prefix') || '';
+      const output = params.get('output');
+      const useThemeBlockParam = params.get('useThemeBlock');
+      // Priority: explicit output setting, else boolean alias
+      const useThemeBlock = output ? (output === 'tailwind') : (useThemeBlockParam === '1' || useThemeBlockParam === 'true');
+
+      const state: AppState = {
+        scales,
+        prefix,
+        useThemeBlock,
+      };
+
+      try {
+        return JSON.stringify(state);
+      } catch {
+        return null;
+      }
+    }
+
+    // Fallback: support legacy hash-based compressed state if present
+    const hash = window.location.hash.slice(1);
+    if (hash) {
+      try {
+        const decompressed = LZString.decompressFromEncodedURIComponent(hash);
+        return decompressed ?? null;
+      } catch {
+        return null;
+      }
+    }
+
+    return null;
+  }
+
+  async setItem(name: string, value: string): Promise<void> {
+    if (typeof window === 'undefined') return;
+
+    try {
+      const parsed = JSON.parse(value) as AppState;
+      const params = new URLSearchParams();
+
+      (parsed.scales || []).forEach((scale) => {
+        params.append('s', this.serializeScaleParam(scale));
+      });
+
+      if (parsed.prefix) {
+        params.set('prefix', parsed.prefix);
+      }
+
+      // Preferred new param: output
+      params.set('output', parsed.useThemeBlock ? 'tailwind' : 'root');
+
+      const query = params.toString();
+      const newUrl = window.location.pathname + (query ? `?${query}` : '');
+      window.history.replaceState(null, '', newUrl);
+    } catch (error) {
+      console.error('Failed to save to query string:', error);
+    }
+  }
+
+  async removeItem(name: string): Promise<void> {
+    if (typeof window === 'undefined') return;
+    try {
+      window.history.replaceState(null, '', window.location.pathname);
+    } catch (error) {
+      console.error('Failed to clear query string:', error);
+    }
+  }
+}
+
 const defaultState: AppState = {
   scales: [],
   prefix: '',
@@ -223,7 +357,7 @@ export const useColorScaleStore = create<ColorScaleStore>()(
       }),
       {
         name: 'color-scale-generator',
-        storage: createJSONStorage(() => new HashStorage()),
+        storage: createJSONStorage(() => new QueryStringStorage()),
         // Only persist the core state, not the history
         partialize: (state) => ({
           scales: state.scales,
@@ -248,6 +382,27 @@ export const useColorScaleStore = create<ColorScaleStore>()(
     )
   )
 );
+
+// Listen for URL popstate changes (browser back/forward) for query string format
+if (typeof window !== 'undefined') {
+  const handlePopState = () => {
+    const store = useColorScaleStore.getState();
+    const loader = new QueryStringStorage();
+    loader.getItem('color-scale-generator').then((json) => {
+      if (json) {
+        try {
+          const newState = JSON.parse(json) as AppState;
+          store._setHistoryIndex(0);
+          store._addToHistory(newState);
+        } catch (error) {
+          console.error('Failed to parse query state:', error);
+        }
+      }
+    });
+  };
+
+  window.addEventListener('popstate', handlePopState);
+}
 
 // Listen for URL hash changes (browser back/forward)
 if (typeof window !== 'undefined') {

--- a/lib/urlStorage.test.ts
+++ b/lib/urlStorage.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { urlStorage } from './urlStorage';
+import { AppState } from './types';
+
+function setLocation(href: string) {
+  // @ts-expect-error allow override for tests
+  delete window.location;
+  // @ts-expect-error allow override for tests
+  window.location = new URL(href) as unknown as Location;
+}
+
+function getHref() {
+  return window.location.pathname + window.location.search + window.location.hash;
+}
+
+describe('urlStorage (query-string format)', () => {
+  const basePath = 'http://localhost/color-scales';
+
+  beforeEach(() => {
+    // Reset location and history.replaceState spy
+    setLocation(basePath);
+    vi.spyOn(window.history, 'replaceState');
+    (window.history.replaceState as unknown as vi.Mock).mockClear();
+  });
+
+  it('parses state from query string with s, prefix, and output', () => {
+    setLocation(
+      `${basePath}?s=primary:%233b82f6,h:10,c:-5&s=danger:%23ef4444&prefix=brand&output=tailwind`
+    );
+
+    const state = urlStorage.getState();
+
+    expect(state.prefix).toBe('brand');
+    expect(state.useThemeBlock).toBe(true); // tailwind => theme block
+    expect(state.scales.length).toBe(2);
+    expect(state.scales[0].name).toBe('primary');
+    expect(state.scales[0].keyColor.toLowerCase()).toBe('#3b82f6');
+    expect(state.scales[0].hueShift).toBe(10);
+    expect(state.scales[0].chromaShift).toBe(-5);
+    expect(state.scales[1].name).toBe('danger');
+    expect(state.scales[1].keyColor.toLowerCase()).toBe('#ef4444');
+  });
+
+  it('respects useThemeBlock boolean alias if output missing', () => {
+    setLocation(`${basePath}?s=primary:%233b82f6&useThemeBlock=1`);
+    const state = urlStorage.getState();
+    expect(state.useThemeBlock).toBe(true);
+  });
+
+  it('falls back to legacy hash compressed state when no query present', () => {
+    // Compose a compressed hash of a simple state
+    const state: AppState = {
+      scales: [
+        { id: 'x', name: 'primary', keyColor: '#3b82f6', hueShift: 0, chromaShift: 0 }
+      ],
+      prefix: 'brand',
+      useThemeBlock: false,
+    };
+    // Import on-demand to access LZString without changing urlStorage export
+    const { default: LZString } = require('lz-string');
+    const compressed = LZString.compressToEncodedURIComponent(JSON.stringify(state));
+
+    setLocation(`${basePath}#${compressed}`);
+    const loaded = urlStorage.getState();
+
+    expect(loaded.scales.length).toBe(1);
+    expect(loaded.prefix).toBe('brand');
+    expect(loaded.useThemeBlock).toBe(false);
+  });
+
+  it('saveState writes query-string with s, prefix, and output', () => {
+    const state: AppState = {
+      scales: [
+        { id: '1', name: 'primary', keyColor: '#3b82f6', hueShift: 0, chromaShift: 0 },
+        { id: '2', name: 'danger', keyColor: '#ef4444', hueShift: 15, chromaShift: -10 },
+      ],
+      prefix: 'brand',
+      useThemeBlock: true,
+    };
+
+    urlStorage.saveState(state);
+
+    // Check that replaceState updated the URL with expected params
+    expect(window.history.replaceState).toHaveBeenCalled();
+    const href = getHref();
+    expect(href).toContain('?');
+    // Both s params exist
+    expect(href).toMatch(/s=primary%3A%253b82f6/i); // name:color (color encoded)
+    expect(href).toMatch(/s=danger%3A%2523ef4444/i);
+    // prefix and output
+    expect(href).toContain('prefix=brand');
+    expect(href).toContain('output=tailwind');
+  });
+
+  it('clear removes query and hash', () => {
+    setLocation(`${basePath}?s=primary:%233b82f6#legacy`);
+
+    urlStorage.clear();
+
+    expect(window.history.replaceState).toHaveBeenCalledWith(null, '', '/color-scales');
+  });
+
+  it('hasData detects query-string state', () => {
+    setLocation(`${basePath}?s=primary:%233b82f6`);
+    expect(urlStorage.hasData()).toBe(true);
+  });
+
+  it('hasData detects legacy hash state', () => {
+    setLocation(`${basePath}#abc`);
+    expect(urlStorage.hasData()).toBe(true);
+  });
+
+  it('getShareableUrl returns current href', () => {
+    setLocation(`${basePath}?prefix=brand`);
+    expect(urlStorage.getShareableUrl()).toContain('/color-scales?prefix=brand');
+  });
+});

--- a/lib/urlStorage.ts
+++ b/lib/urlStorage.ts
@@ -1,19 +1,9 @@
 // ABOUTME: URL-based persistence utilities for color scales and settings
-// ABOUTME: Uses LZString compression to store app state in URL hash
+// ABOUTME: Supports new query-string format and legacy hash compression
 
 import LZString from 'lz-string';
-import { ColorScale } from './colorUtils';
-
-export interface Settings {
-  prefix: string;
-  useThemeBlock: boolean;
-}
-
-export interface AppState {
-  scales: ColorScale[];
-  prefix: string;
-  useThemeBlock: boolean;
-}
+import { generateColorScaleData } from './colorUtils';
+import { AppState, ColorScaleData } from './types';
 
 const defaultState: AppState = {
   scales: [],
@@ -21,33 +11,88 @@ const defaultState: AppState = {
   useThemeBlock: false,
 };
 
-export const urlStorage = {
-  // Get the current state from URL hash
-  getState(): AppState {
+function parseScaleParam(param: string): ColorScaleData | null {
+  try {
+    const firstColon = param.indexOf(':');
+    if (firstColon === -1) return null;
 
+    const rawName = param.slice(0, firstColon);
+    const name = decodeURIComponent(rawName);
+
+    const rest = param.slice(firstColon + 1);
+    const [colorPart, ...restParts] = rest.split(',');
+    const keyColor = decodeURIComponent(colorPart || '').trim();
+
+    if (!keyColor) return null;
+
+    let hueShift = 0;
+    let chromaShift = 0;
+
+    for (const part of restParts) {
+      const sep = part.indexOf(':');
+      if (sep === -1) continue;
+      const k = part.slice(0, sep).trim();
+      const v = part.slice(sep + 1).trim();
+      if (k === 'h') {
+        const n = Number(v);
+        if (!Number.isNaN(n)) hueShift = n;
+      } else if (k === 'c') {
+        const n = Number(v);
+        if (!Number.isNaN(n)) chromaShift = n;
+      }
+    }
+
+    return generateColorScaleData(keyColor, name, hueShift, chromaShift);
+  } catch {
+    return null;
+  }
+}
+
+function serializeScaleParam(scale: ColorScaleData): string {
+  const name = encodeURIComponent(scale.name);
+  const color = encodeURIComponent(scale.keyColor);
+  const parts: string[] = [`${name}:${color}`];
+  if (scale.hueShift && scale.hueShift !== 0) parts.push(`h:${scale.hueShift}`);
+  if (scale.chromaShift && scale.chromaShift !== 0) parts.push(`c:${scale.chromaShift}`);
+  return parts.join(',');
+}
+
+export const urlStorage = {
+  // Get the current state (prefer query string, fallback to hash)
+  getState(): AppState {
     if (typeof window === 'undefined') {
       return defaultState;
     }
 
     try {
-      const hash = window.location.hash.slice(1); // Remove the # symbol
-      console.log('hash', hash);
+      const params = new URLSearchParams(window.location.search);
+      const sParams = params.getAll('s');
+      if (sParams.length > 0 || params.has('prefix') || params.has('useThemeBlock')) {
+        const scales: ColorScaleData[] = [];
+        for (const p of sParams) {
+          const parsed = parseScaleParam(p);
+          if (parsed) scales.push(parsed);
+        }
 
+        const prefix = params.get('prefix') || '';
+        const useThemeBlockParam = params.get('useThemeBlock');
+        const useThemeBlock = useThemeBlockParam === '1' || useThemeBlockParam === 'true';
+
+        return { scales, prefix, useThemeBlock };
+      }
+
+      // Legacy hash format
+      const hash = window.location.hash.slice(1);
       if (!hash) {
-        console.log('No hash found');
-        this.saveState(defaultState);
         return defaultState;
       }
 
       const decompressed = LZString.decompressFromEncodedURIComponent(hash);
       if (!decompressed) {
-        console.log('No decompressed data found');
-        return { scales: [], prefix: '', useThemeBlock: false };
+        return defaultState;
       }
 
       const state = JSON.parse(decompressed);
-      
-      // Validate and provide defaults for missing properties
       return {
         scales: Array.isArray(state.scales) ? state.scales : [],
         prefix: typeof state.prefix === 'string' ? state.prefix : '',
@@ -55,27 +100,31 @@ export const urlStorage = {
       };
     } catch (error) {
       console.error('Failed to load state from URL:', error);
-      return { scales: [], prefix: '', useThemeBlock: false };
+      return defaultState;
     }
   },
 
-  // Save state to URL hash
+  // Save state to query string (new format)
   saveState(state: AppState): void {
     if (typeof window === 'undefined') return;
 
     try {
-      const jsonString = JSON.stringify(state);
-      const compressed = LZString.compressToEncodedURIComponent(jsonString);
-      
-      // Update URL hash without triggering a page reload
-      const newUrl = window.location.pathname + (compressed ? `#${compressed}` : '');
+      const params = new URLSearchParams();
+      (state.scales || []).forEach((scale) => {
+        params.append('s', serializeScaleParam(scale));
+      });
+      if (state.prefix) params.set('prefix', state.prefix);
+      if (state.useThemeBlock) params.set('useThemeBlock', '1');
+
+      const query = params.toString();
+      const newUrl = window.location.pathname + (query ? `?${query}` : '');
       window.history.replaceState(null, '', newUrl);
     } catch (error) {
       console.error('Failed to save state to URL:', error);
     }
   },
 
-  // Clear the URL hash
+  // Clear the URL query and hash
   clear(): void {
     if (typeof window === 'undefined') return;
 
@@ -86,10 +135,13 @@ export const urlStorage = {
     }
   },
 
-  // Check if there's data in the URL
+  // Check if there's data in the URL (query or hash)
   hasData(): boolean {
     if (typeof window === 'undefined') return false;
-    return window.location.hash.length > 1;
+    const params = new URLSearchParams(window.location.search);
+    const hasQuery = params.getAll('s').length > 0 || params.has('prefix') || params.has('useThemeBlock');
+    const hasHash = window.location.hash.length > 1;
+    return hasQuery || hasHash;
   },
 
   // Get URL for sharing
@@ -98,7 +150,7 @@ export const urlStorage = {
     return window.location.href;
   },
 
-  // Listen for URL changes (useful for browser back/forward)
+  // Legacy: Listen for URL hash changes
   onHashChange(callback: (state: AppState) => void): () => void {
     if (typeof window === 'undefined') return () => {};
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitest/ui": "^2.1.9",
     "dotenv-cli": "^10.0.0",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.1.12",
     "typescript": "^5.9.2",
     "vitest": "^2.1.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       dotenv-cli:
         specifier: ^10.0.0
         version: 10.0.0
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       tailwindcss:
         specifier: ^4.1.12
         version: 4.1.12
@@ -83,7 +86,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@20.19.11)(@vitest/ui@2.1.9)(lightningcss@1.30.1)
+        version: 2.1.9(@types/node@20.19.11)(@vitest/ui@2.1.9)(jsdom@26.1.0)(lightningcss@1.30.1)
 
 packages:
 
@@ -91,12 +94,43 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
   '@awesome.me/kit-dafe0a6e6d@1.0.4':
     resolution: {integrity: sha512-o+g+u21R1jKVYJ90MltrVY20J24b4PxAF5e457Ido7HuMsTTvn7032bKxViXZ+dIa5uMcrW0q96dKEUi7Taz4g==}
     engines: {node: '>=16'}
 
   '@bitsandletters/brand-fonts@1.1.0':
     resolution: {integrity: sha512-Dk/06gSxuHWpDVMDW2ZzHKcTBSG49CqrlZaEwoULGotwhvzBjBORTQdGHetwV+lSek25k/D4I6kdJrwjLFpFzQ==, tarball: https://npm.pkg.github.com/download/@bitsandletters/brand-fonts/1.1.0/17889ca3521cce26fe5d649db182363cf8b2fbfd}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
@@ -771,6 +805,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -825,8 +863,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -836,6 +882,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -864,6 +913,10 @@ packages:
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -917,8 +970,27 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -929,6 +1001,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
@@ -1001,6 +1082,9 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1063,9 +1147,15 @@ packages:
       sass:
         optional: true
 
+  nwsapi@2.2.21:
+    resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1096,6 +1186,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
   react-dom@19.1.0:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
@@ -1112,6 +1206,16 @@ packages:
     resolution: {integrity: sha512-BXHRqK1vyt9XVSEHZ9y7xdYtuYbwVod2mLwOMFP7t/Eqoc1pHRlG/WdV2qNeNvZHRQdLedaFycljaYYM96RqJQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -1166,6 +1270,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.2.0:
     resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
@@ -1205,9 +1312,24 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1286,6 +1408,26 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1295,6 +1437,25 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
@@ -1322,11 +1483,39 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
   '@awesome.me/kit-dafe0a6e6d@1.0.4':
     dependencies:
       '@fortawesome/fontawesome-common-types': 7.0.0
 
   '@bitsandletters/brand-fonts@1.1.0': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/runtime@1.4.5':
     dependencies:
@@ -1848,13 +2037,15 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@20.19.11)(@vitest/ui@2.1.9)(lightningcss@1.30.1)
+      vitest: 2.1.9(@types/node@20.19.11)(@vitest/ui@2.1.9)(jsdom@26.1.0)(lightningcss@1.30.1)
 
   '@vitest/utils@2.1.9':
     dependencies:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.2.1
       tinyrainbow: 1.2.0
+
+  agent-base@7.1.4: {}
 
   assertion-error@2.0.1: {}
 
@@ -1910,11 +2101,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.1.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   debug@4.4.1:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -1939,6 +2142,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.3
+
+  entities@6.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -1996,14 +2201,65 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   is-arrayish@0.3.2:
     optional: true
+
+  is-potential-custom-element-name@1.0.1: {}
 
   isexe@2.0.0: {}
 
   jiti@2.5.1: {}
 
   js-tokens@4.0.0: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.21
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   lightningcss-darwin-arm64@1.30.1:
     optional: true
@@ -2056,6 +2312,8 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.18:
@@ -2107,7 +2365,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nwsapi@2.2.21: {}
+
   object-assign@4.1.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-key@3.1.1: {}
 
@@ -2136,6 +2400,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  punycode@2.3.1: {}
 
   react-dom@19.1.0(react@19.1.0):
     dependencies:
@@ -2171,6 +2437,14 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.48.0
       '@rollup/rollup-win32-x64-msvc': 4.48.0
       fsevents: 2.3.3
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.26.0: {}
 
@@ -2237,6 +2511,8 @@ snapshots:
       client-only: 0.0.1
       react: 19.1.0
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.2.0: {}
 
   tailwind-merge@3.3.1: {}
@@ -2269,7 +2545,21 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   totalist@3.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tslib@2.8.1: {}
 
@@ -2309,7 +2599,7 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.1
 
-  vitest@2.1.9(@types/node@20.19.11)(@vitest/ui@2.1.9)(lightningcss@1.30.1):
+  vitest@2.1.9(@types/node@20.19.11)(@vitest/ui@2.1.9)(jsdom@26.1.0)(lightningcss@1.30.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.19(@types/node@20.19.11)(lightningcss@1.30.1))
@@ -2334,6 +2624,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.19.11
       '@vitest/ui': 2.1.9(vitest@2.1.9)
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -2345,6 +2636,23 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2353,6 +2661,12 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@5.0.0: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ import path from 'path';
 
 export default defineConfig({
   test: {
-    environment: 'node',
+    environment: 'jsdom',
     globals: true,
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
Implement a new URL-based state format using query parameters to simplify sharing and improve collaboration.

This PR introduces a `QueryStringStorage` adapter that serializes color scales, prefix, and output format into URL query parameters (e.g., `?s=name:color,h:hue,c:chroma&prefix=my-system&output=tailwind`). It prioritizes reading from the new query format but retains full backward compatibility with the legacy hash-based state. This change addresses Linear issue BNL-93.

---
Linear Issue: [BNL-93](https://linear.app/bitsandletters/issue/BNL-93/try-a-new-simpler-url-based-state-format)

<a href="https://cursor.com/background-agent?bcId=bc-dae47bcb-a6c5-475c-83d9-bc5184b778b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dae47bcb-a6c5-475c-83d9-bc5184b778b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

