### PR TITLE
Fix failing tests

### DIFF
--- a/lib/urlStorage.ts
+++ b/lib/urlStorage.ts
@@ -1,19 +1,10 @@
 // ABOUTME: URL-based persistence utilities for color scales and settings
-// ABOUTME: Uses LZString compression to store app state in URL hash
+// ABOUTME: Supports query-string format and falls back to legacy hash-compressed state
 
 import LZString from 'lz-string';
-import { ColorScale } from './colorUtils';
+import { AppState as PersistedAppState, ColorScaleData } from './types';
 
-export interface Settings {
-  prefix: string;
-  useThemeBlock: boolean;
-}
-
-export interface AppState {
-  scales: ColorScale[];
-  prefix: string;
-  useThemeBlock: boolean;
-}
+type AppState = PersistedAppState;
 
 const defaultState: AppState = {
   scales: [],
@@ -21,61 +12,111 @@ const defaultState: AppState = {
   useThemeBlock: false,
 };
 
-export const urlStorage = {
-  // Get the current state from URL hash
-  getState(): AppState {
+function isTruthyFlag(value: string | null): boolean {
+  if (!value) return false;
+  const normalized = value.toLowerCase();
+  return normalized === '1' || normalized === 'true' || normalized === 'yes';
+}
 
+function decodeScaleParam(param: string): ColorScaleData | null {
+  const [rawName, rawColor] = param.split(':');
+  if (!rawName || !rawColor) return null;
+
+  // Handle colors encoded as "%3b82f6" (where leading '%' represents '#')
+  // Also handle already-decoded '#3b82f6' or bare '3b82f6'
+  let keyColor = rawColor;
+  if (keyColor.startsWith('%')) {
+    keyColor = `#${keyColor.slice(1)}`;
+  } else if (!keyColor.startsWith('#')) {
+    keyColor = `#${keyColor}`;
+  }
+
+  return {
+    id: `scale-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name: rawName,
+    keyColor,
+  };
+}
+
+function encodeColorForQuery(hexColor: string): string {
+  // Expect '#rrggbb' – encode as '%rrggbb' so that URLSearchParams double-encodes '%' to '%25'
+  const normalized = hexColor.startsWith('#') ? hexColor.slice(1) : hexColor;
+  return `%${normalized}`;
+}
+
+export const urlStorage = {
+  // Get current state from URL: prefer query-string, fallback to legacy hash-compressed JSON
+  getState(): AppState {
     if (typeof window === 'undefined') {
       return defaultState;
     }
 
     try {
-      const hash = window.location.hash.slice(1); // Remove the # symbol
-      console.log('hash', hash);
+      const searchParams = new URLSearchParams(window.location.search);
 
-      if (!hash) {
-        console.log('No hash found');
-        this.saveState(defaultState);
-        return defaultState;
+      // New query-string format
+      const scaleParams = searchParams.getAll('s');
+      if (scaleParams.length > 0) {
+        const scales: ColorScaleData[] = scaleParams
+          .map(decodeScaleParam)
+          .filter((s): s is ColorScaleData => Boolean(s));
+
+        const prefix = searchParams.get('prefix') || '';
+        // Map output alias to useThemeBlock
+        const output = (searchParams.get('output') || '').toLowerCase();
+        const themeAlias = searchParams.get('tb') || searchParams.get('theme');
+        const useThemeBlock = output === 'tailwind' || output === 'theme' || isTruthyFlag(themeAlias);
+
+        return { scales, prefix, useThemeBlock };
       }
 
-      const decompressed = LZString.decompressFromEncodedURIComponent(hash);
-      if (!decompressed) {
-        console.log('No decompressed data found');
-        return { scales: [], prefix: '', useThemeBlock: false };
+      // Legacy: hash-compressed JSON using LZString
+      const hash = window.location.hash.slice(1);
+      if (hash) {
+        const decompressed = LZString.decompressFromEncodedURIComponent(hash);
+        if (decompressed) {
+          const state = JSON.parse(decompressed);
+          return {
+            scales: Array.isArray(state.scales) ? state.scales : [],
+            prefix: typeof state.prefix === 'string' ? state.prefix : '',
+            useThemeBlock: typeof state.useThemeBlock === 'boolean' ? state.useThemeBlock : false,
+          };
+        }
       }
 
-      const state = JSON.parse(decompressed);
-      
-      // Validate and provide defaults for missing properties
-      return {
-        scales: Array.isArray(state.scales) ? state.scales : [],
-        prefix: typeof state.prefix === 'string' ? state.prefix : '',
-        useThemeBlock: typeof state.useThemeBlock === 'boolean' ? state.useThemeBlock : false,
-      };
+      return defaultState;
     } catch (error) {
       console.error('Failed to load state from URL:', error);
-      return { scales: [], prefix: '', useThemeBlock: false };
+      return defaultState;
     }
   },
 
-  // Save state to URL hash
+  // Save state to URL query-string (new format)
   saveState(state: AppState): void {
     if (typeof window === 'undefined') return;
 
     try {
-      const jsonString = JSON.stringify(state);
-      const compressed = LZString.compressToEncodedURIComponent(jsonString);
-      
-      // Update URL hash without triggering a page reload
-      const newUrl = window.location.pathname + (compressed ? `#${compressed}` : '');
+      const params = new URLSearchParams();
+      for (const scale of state.scales) {
+        const colorPart = encodeColorForQuery(scale.keyColor);
+        params.append('s', `${scale.name}:${colorPart}`);
+      }
+
+      if (state.prefix) {
+        params.set('prefix', state.prefix);
+      }
+
+      params.set('output', state.useThemeBlock ? 'tailwind' : 'root');
+
+      const query = params.toString();
+      const newUrl = query ? `${window.location.pathname}?${query}` : window.location.pathname;
       window.history.replaceState(null, '', newUrl);
     } catch (error) {
       console.error('Failed to save state to URL:', error);
     }
   },
 
-  // Clear the URL hash
+  // Clear the URL (remove query and hash)
   clear(): void {
     if (typeof window === 'undefined') return;
 
@@ -86,10 +127,11 @@ export const urlStorage = {
     }
   },
 
-  // Check if there's data in the URL
+  // Check if there's data in the URL (query-string or legacy hash)
   hasData(): boolean {
     if (typeof window === 'undefined') return false;
-    return window.location.hash.length > 1;
+    const searchParams = new URLSearchParams(window.location.search);
+    return searchParams.has('s') || window.location.hash.length > 1;
   },
 
   // Get URL for sharing
@@ -98,20 +140,21 @@ export const urlStorage = {
     return window.location.href;
   },
 
-  // Listen for URL changes (useful for browser back/forward)
+  // Listen for navigation changes that might alter state (use popstate for query changes)
   onHashChange(callback: (state: AppState) => void): () => void {
     if (typeof window === 'undefined') return () => {};
 
-    const handleHashChange = () => {
+    const handleChange = () => {
       const state = urlStorage.getState();
       callback(state);
     };
 
-    window.addEventListener('hashchange', handleHashChange);
+    window.addEventListener('popstate', handleChange);
+    window.addEventListener('hashchange', handleChange);
     
-    // Return cleanup function
     return () => {
-      window.removeEventListener('hashchange', handleHashChange);
+      window.removeEventListener('popstate', handleChange);
+      window.removeEventListener('hashchange', handleChange);
     };
   }
-}; 
+};

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "dotenv vitest run",
-    "test:ui": "dotenv vitest run --ui",
-    "test:coverage": "dotenv vitest run --coverage"
+    "test": "vitest run",
+    "test:ui": "vitest run --ui",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@awesome.me/kit-dafe0a6e6d": "^1.0.4",


### PR DESCRIPTION
Implement URL query-string parsing and saving with legacy hash fallback to fix failing state persistence tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-db8daee8-0f7d-4ff0-9cd2-7711389d862d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db8daee8-0f7d-4ff0-9cd2-7711389d862d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

